### PR TITLE
bug: fix the path of the TPU-MLIR in sd-lcm doc

### DIFF
--- a/docs/common/ai/_sd_lcm.mdx
+++ b/docs/common/ai/_sd_lcm.mdx
@@ -21,7 +21,7 @@ Stable Diffusion 是一个可以根据文本生成相应场景照片的生成式
 
   - [RealCartoon2.5D](https://civitai.com/models/218376/realcartoon-25d)
 
-  用户也可通过 model_export.py 与 [TPU-MLIR](../model-compile) 编译任何 stable_diffusion v1.5 checkpoints, 具体请参考 [model_export/README.md](https://github.com/zifeng-radxa/SD-lcm-tpu/blob/radxa_v0.2.0/model_export/README.md)
+  用户也可通过 model_export.py 与 [TPU-MLIR](../../model-compile) 编译任何 stable_diffusion v1.5 checkpoints, 具体请参考 [model_export/README.md](https://github.com/zifeng-radxa/SD-lcm-tpu/blob/radxa_v0.2.0/model_export/README.md)
 
   预编译中只有 awportrait.tar.gz 包含 VAE, 如有需要请自行下载 VAE, 参考并修改 model_path.py 中各模型路径
 


### PR DESCRIPTION
bug: fix the path of the TPU-MLIR in sd-lcm doc